### PR TITLE
Add linkcheck step to be run once a week

### DIFF
--- a/.github/workflows/linkcheck.yml
+++ b/.github/workflows/linkcheck.yml
@@ -1,0 +1,74 @@
+name: External links checker
+
+on:
+  repository_dispatch:
+  workflow_dispatch: # can also be triggered manually
+  schedule:
+    - cron: "0 0 * * *" # every sunday at midnight
+
+jobs:
+  linkChecker:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Clone docs repo
+        uses: actions/checkout@v4
+        with:
+          # place in '/home/runner/work/docs/docs/docs'
+          path: docs  # place in a named directory
+
+      - name: Clone main repo
+        uses: actions/checkout@v4
+        with:
+          # place in '/home/runner/work/docs/docs/napari'
+          path: napari  # place in a named directory
+          repository: napari/napari
+          # ensure version metadata is proper
+          fetch-depth: 0
+
+      - uses: actions/setup-python@v5
+        with:
+          python-version: "3.10"
+          cache-dependency-path: |
+            napari/pyproject.toml
+            docs/requirements.txt
+
+      - uses: tlambert03/setup-qt-libs@v1
+
+      - name: Install Dependencies
+        run: |
+          python -m pip install --upgrade pip
+          python -m pip install "napari/[all]"
+        env:
+          PIP_CONSTRAINT: ${{ github.workspace }}/napari/resources/constraints/constraints_py3.10_docs.txt
+
+      # - name: Create fallback videos
+      #   run: |
+      #     sudo apt-get update && sudo apt-get install -y ffmpeg
+      #     cd docs
+      #     make fallback-videos
+
+      - name: Build Docs
+        uses: aganders3/headless-gui@v2
+        env:
+          GOOGLE_CALENDAR_ID: ${{ secrets.GOOGLE_CALENDAR_ID }}
+          GOOGLE_CALENDAR_API_KEY: ${{ secrets.GOOGLE_CALENDAR_API_KEY }}
+          PIP_CONSTRAINT: ${{ github.workspace }}/napari/resources/constraints/constraints_py3.10_docs.txt
+        with:
+          # Runs in '/home/runner/work/docs/docs/docs'
+          # Built HTML pages in '/home/runner/work/docs/docs/docs/docs/_build/html'
+          run:  make -C docs linkcheck-files
+          # skipping setup stops the action from running the default (tiling) window manager
+          # the window manager is not necessary for docs builds at this time and it was causing
+          # problems with screenshots (https://github.com/napari/docs/issues/285)
+          linux-setup: "echo 'skip setup'"
+          linux-teardown: "echo 'skip teardown'"
+
+      - name: Create Issue From File
+        if: env.lychee_exit_code != 0
+        uses: peter-evans/create-issue-from-file@v4
+        with:
+          title: Link Checker Report
+          content-filepath: ./docs/docs/_build/html/output.txt
+          labels: maintenance, task


### PR DESCRIPTION
# Description
Add sphinx linkchecker step to be run once a week.

Can also be triggered manually. It creates an issue when broken links are found in the documentation, including docstrings.

