### PR TITLE
Add linkcheck step to be run once a week

### DIFF
--- a/.github/workflows/linkcheck.yml
+++ b/.github/workflows/linkcheck.yml
@@ -1,0 +1,70 @@
+name: External links checker
+
+on:
+  repository_dispatch:
+  workflow_dispatch: # can also be triggered manually
+  schedule:
+    - cron: "0 0 * * *" # every sunday at midnight
+
+jobs:
+  link-check:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Clone docs repo
+        uses: actions/checkout@v4
+        with:
+          # place in '/home/runner/work/docs/docs/docs'
+          path: docs  # place in a named directory
+
+      - name: Clone main repo
+        uses: actions/checkout@v4
+        with:
+          # place in '/home/runner/work/docs/docs/napari'
+          path: napari  # place in a named directory
+          repository: napari/napari
+          # ensure version metadata is proper
+          fetch-depth: 0
+
+      - uses: actions/setup-python@v5
+        with:
+          python-version: "3.10"
+          cache-dependency-path: |
+            napari/pyproject.toml
+            docs/requirements.txt
+
+      - uses: tlambert03/setup-qt-libs@v1
+
+      - name: Install Dependencies
+        run: |
+          python -m pip install --upgrade pip
+          python -m pip install "napari/[all]"
+        env:
+          PIP_CONSTRAINT: ${{ github.workspace }}/napari/resources/constraints/constraints_py3.10_docs.txt
+
+      - name: Run link checker
+        uses: aganders3/headless-gui@v2
+        env:
+          GOOGLE_CALENDAR_ID: ${{ secrets.GOOGLE_CALENDAR_ID }}
+          GOOGLE_CALENDAR_API_KEY: ${{ secrets.GOOGLE_CALENDAR_API_KEY }}
+          PIP_CONSTRAINT: ${{ github.workspace }}/napari/resources/constraints/constraints_py3.10_docs.txt
+        with:
+          # Runs in '/home/runner/work/docs/docs/docs'
+          # Built HTML pages in '/home/runner/work/docs/docs/docs/docs/_build/html'
+          run:  |
+            python -m pip install -r docs/requirements.txt
+            make -C docs linkcheck-files
+          # skipping setup stops the action from running the default (tiling) window manager
+          # the window manager is not necessary for docs builds at this time and it was causing
+          # problems with screenshots (https://github.com/napari/docs/issues/285)
+          linux-setup: "echo 'skip setup'"
+          linux-teardown: "echo 'skip teardown'"
+
+      - name: Create issue from file
+        if: ${{ failure() }}
+        uses: peter-evans/create-issue-from-file@v4
+        with:
+          title: Link Checker Report
+          content-filepath: ./docs/docs/_build/html/output.txt
+          labels: maintenance, task


### PR DESCRIPTION
Can also be triggered manually. It creates an issue when broken links are found in the documentation, including docstrings.

# References and relevant issues
<!-- What relevant resources were used in the creation of this PR?
If this PR addresses an existing issue on the repo,
please link to that issue here as "Closes #(issue-number)".
If this PR adds docs for a napari PR please add a "Depends on <napari PR link>" -->

# Description
<!-- What does this pull request (PR) do? Does it add new content, improve/fix existing
context, improve/fix workflow/documentation build/deployment or something else?
<!-- If relevant, please include a screenshot or a screen capture in your content
change: "An image is worth a thousand words!" -->
<!-- You can use https://www.cockos.com/licecap/ or similar to create animations. -->
<!-- You can also see a preview of the documentation changes you are submitting by
clicking on "Details" to the right of the "Check the rendered docs here!" check on your PR.-->

<!-- Final Checklist
- If images included: I have added [alt text](https://webaim.org/techniques/alttext/)
If workflow, documentation build or deployment change:
- My PR is the minimum possible work for the desired functionality
- I have commented my code, to let others know what it does
-->
